### PR TITLE
Eliminate warnings from test run via pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings


### PR DESCRIPTION
The modification to pytest.ini aim to fix [issue 19](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
)